### PR TITLE
Moved functions result type to the right place in @method definitions

### DIFF
--- a/src/Facades/NotificationSubscriptionManager.php
+++ b/src/Facades/NotificationSubscriptionManager.php
@@ -7,12 +7,12 @@ use Illuminate\Support\Facades\Facade;
 /**
  * Class NotificationSubscriptionManager
  * @package Asantibanez\LaravelSubscribableNotifications\Facades
- * @method static subscribableNotifications(): array
- * @method static subscribe($user, $subscribableNotificationClass): void
- * @method static unsubscribe($user, $subscribableNotificationClass): void
- * @method static unsubscribeFromAll($user): void
- * @method static userModel(): string
- * @method static guessUserLabel($user): string
+ * @method static array subscribableNotifications()
+ * @method static void subscribe($user, $subscribableNotificationClass)
+ * @method static void unsubscribe($user, $subscribableNotificationClass)
+ * @method static void unsubscribeFromAll($user)
+ * @method static string userModel()
+ * @method static string guessUserLabel($user)
  */
 class NotificationSubscriptionManager extends Facade
 {


### PR DESCRIPTION
Fixed function type definitions of facade class NotificationSubscriptionManager. To avoid non-static call errors in development.